### PR TITLE
Reset camera state for each image generation and Create focusCameraFactory interface to align the direction of protein based on the first residue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,12 @@
     "build/bin/molrender.js"
   ],
   "author": "Mol* Contributors",
+  "contributors": [
+    "Jesse Liang <jesse.liang@rcsb.org>",
+    "Alexander Rose <alexander.rose@weirdbyte.de>",
+    "Sebastian Bittrich <sebastian.bittrich@rcsb.org>",
+    "Ke Ma <mark.ma@rcsb.org>"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@types/argparse": "^2.0.10",

--- a/src/focus-camera/focus-factory-interface.ts
+++ b/src/focus-camera/focus-factory-interface.ts
@@ -1,7 +1,7 @@
-import { Structure } from "molstar/lib/mol-model/structure";
-import { ImageRenderer } from "../render";
+import { Structure } from 'molstar/lib/mol-model/structure';
+import { ImageRenderer } from '../render';
 
 export interface FocusFactoryI {
-    getFocus(imageRender: ImageRenderer):(structure: Structure)=>void;
+    getFocus(imageRender: ImageRenderer): (structure: Structure) => void;
 }
 

--- a/src/focus-camera/focus-factory-interface.ts
+++ b/src/focus-camera/focus-factory-interface.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Ke Ma <mark.ma@rcsb.org>
+ */
+
 import { Structure } from 'molstar/lib/mol-model/structure';
 import { ImageRenderer } from '../render';
 

--- a/src/focus-camera/focus-factory-interface.ts
+++ b/src/focus-camera/focus-factory-interface.ts
@@ -1,0 +1,7 @@
+import { Structure } from "molstar/lib/mol-model/structure";
+import { ImageRenderer } from "../render";
+
+export interface FocusFactoryI {
+    getFocus(imageRender: ImageRenderer):(structure: Structure)=>void;
+}
+

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -10,7 +10,10 @@ export class FocusFirstResidue implements FocusFactoryI {
         
         return (structure: Structure) => {
 
-            imageRender.canvas3d.camera.setState(Camera.createDefaultSnapshot());
+            imageRender.canvas3d.camera.setState({
+                ...Camera.createDefaultSnapshot(),
+                mode:"orthographic"
+            });
             const caPositions=getPositions(structure)
             const principalAxes = PrincipalAxes.ofPositions(caPositions);
             
@@ -43,9 +46,7 @@ export class FocusFirstResidue implements FocusFactoryI {
             if(dirA[1]<=0){
                 Vec3.negate(imageRender.canvas3d.camera.up,imageRender.canvas3d.camera.up)
             }
-            imageRender.canvas3d.camera.setState({mode:'orthographic'});
-
-             imageRender.canvas3d.camera.focus(origin, radius, 0, dirA,dirC);
+            imageRender.canvas3d.camera.focus(origin, radius, 0, dirA,dirC);
             // ensure nothing is clipped off in the front
             const state = Camera.copySnapshot(Camera.createDefaultSnapshot(), imageRender.canvas3d.camera.state);
             state.radius = structure.boundary.sphere.radius;

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Ke Ma <mark.ma@rcsb.org>
+ */
+
 import { Camera } from 'molstar/lib/mol-canvas3d/camera';
 import { Structure } from 'molstar/lib/mol-model/structure';
 import { FocusFactoryI } from './focus-factory-interface';

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -43,7 +43,8 @@ export class FocusFirstResidue implements FocusFactoryI {
             if(Vec3.dot(deltaDistance,dirC)<=0){
                 Vec3.negate(imageRender.canvas3d.camera.position,position)
             }
-            if(dirA[1]<=0){
+            const up = Vec3.create(0, 1, 0);
+            if(Vec3.dot(up,dirA)<=0){
                 Vec3.negate(imageRender.canvas3d.camera.up,imageRender.canvas3d.camera.up)
             }
             imageRender.canvas3d.camera.focus(origin, radius, 0, dirA,dirC);

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -1,0 +1,64 @@
+import { Camera } from "molstar/lib/mol-canvas3d/camera";
+import { Structure } from "molstar/lib/mol-model/structure";
+import { FocusFactoryI } from "./focus-factory-interface";
+import { getPositions, ImageRenderer } from "../render"
+import { PrincipalAxes } from "molstar/lib/mol-math/linear-algebra/matrix/principal-axes";
+import { Vec3 } from "molstar/lib/mol-math/linear-algebra/3d/vec3";
+import { calculateDisplacement } from "./focus-util";
+export class FocusFirstResidue implements FocusFactoryI {
+    public getFocus(imageRender: ImageRenderer): (structure: Structure) => void {
+        
+        return (structure: Structure) => {
+
+            imageRender.canvas3d.camera.setState(Camera.createDefaultSnapshot());
+            const caPositions=getPositions(structure)
+            const principalAxes = PrincipalAxes.ofPositions(caPositions);
+            
+            let { origin,dirA,dirB,dirC } = principalAxes.boxAxes;
+
+            const toFlip=this.getAxesToFlip(caPositions,origin,dirA,dirB)
+            toFlip.forEach((axis)=>{
+                if(axis=='aroundY'){
+                    Vec3.negate(dirC,dirC)
+                }
+                else if(axis=='aroundX'){
+                    Vec3.negate(dirA,dirA)
+                    Vec3.negate(dirC,dirC)
+                }
+            })
+
+            const radius = Vec3.magnitude(dirC);
+            // move camera far in the direction from the origin, so we get a view from the outside
+            const position = Vec3();
+            Vec3.scaleAndAdd(position, position, origin, 100);
+            imageRender.canvas3d.camera.setState({position}, 0);
+            // tight zoom
+
+            // Counteract the matchDirection() in focus()
+            const deltaDistance=Vec3();
+            Vec3.negate(deltaDistance,position);
+            if(Vec3.dot(deltaDistance,dirC)<=0){
+                Vec3.negate(imageRender.canvas3d.camera.position,position)
+            }
+            if(dirA[1]<=0){
+                Vec3.negate(imageRender.canvas3d.camera.up,imageRender.canvas3d.camera.up)
+            }
+            imageRender.canvas3d.camera.setState({mode:'orthographic'});
+
+             imageRender.canvas3d.camera.focus(origin, radius, 0, dirA,dirC);
+            // ensure nothing is clipped off in the front
+            const state = Camera.copySnapshot(Camera.createDefaultSnapshot(), imageRender.canvas3d.camera.state);
+            state.radius = structure.boundary.sphere.radius;
+            state.radiusMax = structure.boundary.sphere.radius;
+            imageRender.canvas3d.camera.setState(state);
+        };
+    }
+    getAxesToFlip(positions: Float32Array, origin:Vec3, up: Vec3, normalDir:Vec3){
+        const toYAxis=calculateDisplacement(positions,origin,normalDir)
+        const toXAxis=calculateDisplacement(positions,origin,up)
+        let Axes: string[] = []
+        if(toYAxis[0]<0) Axes.push('aroundY')
+        if(toXAxis[0]<0) Axes.push('aroundX')
+        return Axes
+    } 
+}

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -1,53 +1,52 @@
-import { Camera } from "molstar/lib/mol-canvas3d/camera";
-import { Structure } from "molstar/lib/mol-model/structure";
-import { FocusFactoryI } from "./focus-factory-interface";
-import { getPositions, ImageRenderer } from "../render"
-import { PrincipalAxes } from "molstar/lib/mol-math/linear-algebra/matrix/principal-axes";
-import { Vec3 } from "molstar/lib/mol-math/linear-algebra/3d/vec3";
-import { calculateDisplacement } from "./focus-util";
+import { Camera } from 'molstar/lib/mol-canvas3d/camera';
+import { Structure } from 'molstar/lib/mol-model/structure';
+import { FocusFactoryI } from './focus-factory-interface';
+import { getPositions, ImageRenderer } from '../render';
+import { PrincipalAxes } from 'molstar/lib/mol-math/linear-algebra/matrix/principal-axes';
+import { Vec3 } from 'molstar/lib/mol-math/linear-algebra/3d/vec3';
+import { calculateDisplacement } from './focus-util';
 export class FocusFirstResidue implements FocusFactoryI {
     public getFocus(imageRender: ImageRenderer): (structure: Structure) => void {
-        
+
         return (structure: Structure) => {
 
             imageRender.canvas3d.camera.setState({
                 ...Camera.createDefaultSnapshot(),
-                mode:"orthographic"
+                mode: 'orthographic'
             });
-            const caPositions=getPositions(structure)
+            const caPositions = getPositions(structure);
             const principalAxes = PrincipalAxes.ofPositions(caPositions);
-            
-            let { origin,dirA,dirB,dirC } = principalAxes.boxAxes;
 
-            const toFlip=this.getAxesToFlip(caPositions,origin,dirA,dirB)
+            const { origin, dirA, dirB, dirC } = principalAxes.boxAxes;
+
+            const toFlip = this.getAxesToFlip(caPositions, origin, dirA, dirB);
             toFlip.forEach((axis)=>{
-                if(axis=='aroundY'){
-                    Vec3.negate(dirC,dirC)
+                if (axis === 'aroundY') {
+                    Vec3.negate(dirC, dirC);
+                } else if (axis === 'aroundX') {
+                    Vec3.negate(dirA, dirA);
+                    Vec3.negate(dirC, dirC);
                 }
-                else if(axis=='aroundX'){
-                    Vec3.negate(dirA,dirA)
-                    Vec3.negate(dirC,dirC)
-                }
-            })
+            });
 
             const radius = Vec3.magnitude(dirC);
             // move camera far in the direction from the origin, so we get a view from the outside
             const position = Vec3();
             Vec3.scaleAndAdd(position, position, origin, 100);
-            imageRender.canvas3d.camera.setState({position}, 0);
+            imageRender.canvas3d.camera.setState({ position }, 0);
             // tight zoom
 
             // Counteract the matchDirection() in focus()
-            const deltaDistance=Vec3();
-            Vec3.negate(deltaDistance,position);
-            if(Vec3.dot(deltaDistance,dirC)<=0){
-                Vec3.negate(imageRender.canvas3d.camera.position,position)
+            const deltaDistance = Vec3();
+            Vec3.negate(deltaDistance, position);
+            if (Vec3.dot(deltaDistance, dirC) <= 0) {
+                Vec3.negate(imageRender.canvas3d.camera.position, position);
             }
             const up = Vec3.create(0, 1, 0);
-            if(Vec3.dot(up,dirA)<=0){
-                Vec3.negate(imageRender.canvas3d.camera.up,imageRender.canvas3d.camera.up)
+            if (Vec3.dot(up, dirA) <= 0) {
+                Vec3.negate(imageRender.canvas3d.camera.up, imageRender.canvas3d.camera.up);
             }
-            imageRender.canvas3d.camera.focus(origin, radius, 0, dirA,dirC);
+            imageRender.canvas3d.camera.focus(origin, radius, 0, dirA, dirC);
             // ensure nothing is clipped off in the front
             const state = Camera.copySnapshot(Camera.createDefaultSnapshot(), imageRender.canvas3d.camera.state);
             state.radius = structure.boundary.sphere.radius;
@@ -55,12 +54,12 @@ export class FocusFirstResidue implements FocusFactoryI {
             imageRender.canvas3d.camera.setState(state);
         };
     }
-    getAxesToFlip(positions: Float32Array, origin:Vec3, up: Vec3, normalDir:Vec3){
-        const toYAxis=calculateDisplacement(positions,origin,normalDir)
-        const toXAxis=calculateDisplacement(positions,origin,up)
-        let Axes: string[] = []
-        if(toYAxis[0]<0) Axes.push('aroundY')
-        if(toXAxis[0]<0) Axes.push('aroundX')
-        return Axes
-    } 
+    getAxesToFlip(positions: Float32Array, origin: Vec3, up: Vec3, normalDir: Vec3) {
+        const toYAxis = calculateDisplacement(positions, origin, normalDir);
+        const toXAxis = calculateDisplacement(positions, origin, up);
+        const Axes: string[] = [];
+        if (toYAxis[0] < 0) Axes.push('aroundY');
+        if (toXAxis[0] < 0) Axes.push('aroundX');
+        return Axes;
+    }
 }

--- a/src/focus-camera/focus-util.ts
+++ b/src/focus-camera/focus-util.ts
@@ -1,17 +1,17 @@
 import { Vec3 } from 'molstar/lib/mol-math/linear-algebra';
 
-export function calculateDisplacement(positions: Float32Array, origin: Vec3, normalDir: Vec3){
-    const toReturn=new Float32Array(positions.length/3)
-    const A=normalDir[0];
-    const B=normalDir[1];
-    const C=normalDir[2]; 
-    const D=-A*origin[0]-B*origin[1]-C*origin[2];
-    for(let i=0; i<positions.length; i+=3){
-        const x=positions[i];
-        const y=positions[i+1];
-        const z=positions[i+2];
-        const displacement= (A*x+B*y+C*z+D)/Math.sqrt(A*A+B*B+C*C)
-        toReturn[i/3]=displacement;
+export function calculateDisplacement(positions: Float32Array, origin: Vec3, normalDir: Vec3) {
+    const toReturn = new Float32Array(positions.length / 3);
+    const A = normalDir[0];
+    const B = normalDir[1];
+    const C = normalDir[2];
+    const D = -A * origin[0] - B * origin[1] - C * origin[2];
+    for (let i = 0; i < positions.length; i += 3) {
+        const x = positions[i];
+        const y = positions[i + 1];
+        const z = positions[i + 2];
+        const displacement = (A * x + B * y + C * z + D) / Math.sqrt(A * A + B * B + C * C);
+        toReturn[i / 3] = displacement;
     }
     return toReturn;
 }

--- a/src/focus-camera/focus-util.ts
+++ b/src/focus-camera/focus-util.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Ke Ma <mark.ma@rcsb.org>
+ */
+
 import { Vec3 } from 'molstar/lib/mol-math/linear-algebra';
 
 export function calculateDisplacement(positions: Float32Array, origin: Vec3, normalDir: Vec3) {

--- a/src/focus-camera/focus-util.ts
+++ b/src/focus-camera/focus-util.ts
@@ -1,0 +1,18 @@
+import { Vec3 } from 'molstar/lib/mol-math/linear-algebra';
+
+export function calculateDisplacement(positions: Float32Array, origin: Vec3, normalDir: Vec3){
+    const toReturn=new Float32Array(positions.length/3)
+    const A=normalDir[0];
+    const B=normalDir[1];
+    const C=normalDir[2]; 
+    const D=-A*origin[0]-B*origin[1]-C*origin[2];
+    for(let i=0; i<positions.length; i+=3){
+        const x=positions[i];
+        const y=positions[i+1];
+        const z=positions[i+2];
+        const displacement= (A*x+B*y+C*z+D)/Math.sqrt(A*A+B*B+C*C)
+        toReturn[i/3]=displacement;
+    }
+    return toReturn;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  * @author Jesse Liang <jesse.liang@rcsb.org>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ * @author Ke Ma <mark.ma@rcsb.org>
  */
 
 import * as argparse from 'argparse';

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export function getFileName(inPath: string) {
 }
 
 async function main() {
-    const renderer = new ImageRenderer(args.width, args.height, args.format, args.plddt,new FocusFirstResidue());
+    const renderer = new ImageRenderer(args.width, args.height, args.format, args.plddt, new FocusFirstResidue());
 
     const fileName = getFileName(args.in);
     const cif = await readCifFile(args.in);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { ImageRenderer } from './render';
 import { CifFrame } from 'molstar/lib/mol-io/reader/cif';
 import { getTrajectory, readCifFile } from './util';
 import { Task } from 'molstar/lib/mol-task';
+import { FocusFirstResidue } from './focus-camera/focus-first-residue';
 
 const parser = new argparse.ArgumentParser({
     add_help: true,
@@ -101,7 +102,7 @@ export function getFileName(inPath: string) {
 }
 
 async function main() {
-    const renderer = new ImageRenderer(args.width, args.height, args.format, args.plddt);
+    const renderer = new ImageRenderer(args.width, args.height, args.format, args.plddt,new FocusFirstResidue());
 
     const fileName = getFileName(args.in);
     const cif = await readCifFile(args.in);

--- a/src/render.ts
+++ b/src/render.ts
@@ -153,7 +153,7 @@ export class ImageRenderer {
     imagePass: ImagePass;
     assetManager = new AssetManager();
 
-    constructor(private width: number, private height: number, private format: 'png' | 'jpeg', private plddt: 'on' | 'single-chain' | 'off',focusFactory?: FocusFactoryI) {
+    constructor(private width: number, private height: number, private format: 'png' | 'jpeg', private plddt: 'on' | 'single-chain' | 'off', focusFactory?: FocusFactoryI) {
         this.webgl = createContext(getGLContext(this.width, this.height, {
             antialias: true,
             preserveDrawingBuffer: true,
@@ -162,8 +162,8 @@ export class ImageRenderer {
             premultipliedAlpha: true, // the renderer outputs PMA
         }));
 
-        if(focusFactory) this.focusCamera = focusFactory.getFocus(this);
-        
+        if (focusFactory) this.focusCamera = focusFactory.getFocus(this);
+
         const input = InputObserver.create();
         const attribs = { ...DefaultAttribs };
         const passes = new Passes(this.webgl, attribs);
@@ -349,7 +349,7 @@ export class ImageRenderer {
     focusCamera(structure: Structure) {
         this.canvas3d.camera.setState({
             ...Camera.createDefaultSnapshot(),
-            mode:"orthographic"
+            mode: 'orthographic'
         });
         const principalAxes = PrincipalAxes.ofPositions(getPositions(structure));
         const { origin, dirA, dirC } = principalAxes.boxAxes;

--- a/src/render.ts
+++ b/src/render.ts
@@ -50,6 +50,7 @@ import { ColorNames } from 'molstar/lib/mol-util/color/names';
 import { PLDDTConfidenceColorThemeProvider } from 'molstar/lib/extensions/model-archive/quality-assessment/color/plddt';
 import { FocusExpression, FocusExpressionNoBranched,
     RepresentationExpression, RepresentationExpressionNoBranched, SmallFocusExpression } from './expression';
+import { FocusFactoryI } from './focus-camera/focus-factory-interface';
 
 /**
  * Helper method to create PNG with given PNG data
@@ -67,7 +68,7 @@ async function writeJpegFile(jpeg: JPEG.BufferRet, outPath: string) {
 }
 
 const tmpMatrixPos = Vec3.zero();
-function getPositions(structure: Structure) {
+export function getPositions(structure: Structure) {
     const positions = new Float32Array(structure.elementCount * 3);
     for (let i = 0, m = 0, il = structure.units.length; i < il; ++i) {
         const unit = structure.units[i];
@@ -152,7 +153,7 @@ export class ImageRenderer {
     imagePass: ImagePass;
     assetManager = new AssetManager();
 
-    constructor(private width: number, private height: number, private format: 'png' | 'jpeg', private plddt: 'on' | 'single-chain' | 'off') {
+    constructor(private width: number, private height: number, private format: 'png' | 'jpeg', private plddt: 'on' | 'single-chain' | 'off',focusFactory?: FocusFactoryI) {
         this.webgl = createContext(getGLContext(this.width, this.height, {
             antialias: true,
             preserveDrawingBuffer: true,
@@ -161,6 +162,8 @@ export class ImageRenderer {
             premultipliedAlpha: true, // the renderer outputs PMA
         }));
 
+        if(focusFactory) this.focusCamera = focusFactory.getFocus(this);
+        
         const input = InputObserver.create();
         const attribs = { ...DefaultAttribs };
         const passes = new Passes(this.webgl, attribs);

--- a/src/render.ts
+++ b/src/render.ts
@@ -6,6 +6,8 @@
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
 
+//This is my branch
+
 import getGLContext = require('gl');
 import fs = require('fs');
 import { PNG } from 'pngjs';

--- a/src/render.ts
+++ b/src/render.ts
@@ -6,8 +6,6 @@
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
 
-//This is my branch
-
 import getGLContext = require('gl');
 import fs = require('fs');
 import { PNG } from 'pngjs';
@@ -346,6 +344,7 @@ export class ImageRenderer {
     }
 
     focusCamera(structure: Structure) {
+        this.canvas3d.camera.setState(Camera.createDefaultSnapshot());
         const principalAxes = PrincipalAxes.ofPositions(getPositions(structure));
         const { origin, dirA, dirC } = principalAxes.boxAxes;
         const radius = Vec3.magnitude(dirA);

--- a/src/render.ts
+++ b/src/render.ts
@@ -4,6 +4,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Jesse Liang <jesse.liang@rcsb.org>
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ * @author Ke Ma <mark.ma@rcsb.org>
  */
 
 import getGLContext = require('gl');

--- a/src/render.ts
+++ b/src/render.ts
@@ -347,7 +347,10 @@ export class ImageRenderer {
     }
 
     focusCamera(structure: Structure) {
-        this.canvas3d.camera.setState(Camera.createDefaultSnapshot());
+        this.canvas3d.camera.setState({
+            ...Camera.createDefaultSnapshot(),
+            mode:"orthographic"
+        });
         const principalAxes = PrincipalAxes.ofPositions(getPositions(structure));
         const { origin, dirA, dirC } = principalAxes.boxAxes;
         const radius = Vec3.magnitude(dirA);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,4 +30,4 @@ module.exports = [
         entry: path.resolve(__dirname, `build/src/index.js`),
         output: { filename: `molrender.js`, path: path.resolve(__dirname, `build/bin`) },
     }
-]
+];


### PR DESCRIPTION
Chain images generated with  
`molrender all ./12c8.cif ./`
are different from
`molrender chain ./12c8.cif ./ A && molrender chain ./12c8.cif ./ B && molrender chain ./12c8.cif ./ C && molrender chain ./12c8.cif ./ D`
Is that intended?
Reseting camera state before generating the image seems to fix the problem. 