### PR TITLE
orientation change of multiple chain structures based on first chain + chain-list rendering

### DIFF
--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Ke Ma <mark.ma@rcsb.org>
  */
@@ -25,15 +25,13 @@ export class FocusFirstResidue implements FocusFactoryI {
             const positionToFlip = getFirstResidueOrAveragePosition(structure, caPositions);
             const { origin, dirA, dirB, dirC } = principalAxes.boxAxes;
 
-            const toFlip = this.getAxesToFlip(positionToFlip, origin, dirA, dirB);
-            toFlip.forEach((axis)=>{
-                if (axis === 'aroundY') {
-                    Vec3.negate(dirC, dirC);
-                } else if (axis === 'aroundX') {
-                    Vec3.negate(dirA, dirA);
-                    Vec3.negate(dirC, dirC);
-                }
-            });
+            const { aroundX, aroundY } = getAxesToFlip(positionToFlip, origin, dirA, dirB);
+            if (aroundY) {
+                Vec3.negate(dirC, dirC);
+            } else if (aroundX) {
+                Vec3.negate(dirA, dirA);
+                Vec3.negate(dirC, dirC);
+            }
 
             const radius = Vec3.magnitude(dirC);
             // move camera far in the direction from the origin, so we get a view from the outside
@@ -60,50 +58,37 @@ export class FocusFirstResidue implements FocusFactoryI {
             imageRender.canvas3d.camera.setState(state);
         };
     }
-    getAxesToFlip(position: Vec3, origin: Vec3, up: Vec3, normalDir: Vec3) {
-        const toYAxis = calculateDisplacement(position, origin, normalDir);
-        const toXAxis = calculateDisplacement(position, origin, up);
-        const Axes: string[] = [];
-        if (toYAxis < 0) Axes.push('aroundY');
-        if (toXAxis < 0) Axes.push('aroundX');
-        return Axes;
-    }
+}
+
+function getAxesToFlip(position: Vec3, origin: Vec3, up: Vec3, normalDir: Vec3) {
+    const toYAxis = calculateDisplacement(position, origin, normalDir);
+    const toXAxis = calculateDisplacement(position, origin, up);
+    return {
+        aroundX: toXAxis < 0,
+        aroundY: toYAxis < 0,
+    };
 }
 
 function getFirstResidueOrAveragePosition(structure: Structure, caPositions: Float32Array): Vec3 {
-    //TODO Is this the best way to test single chain?
     // if only one chain => first residue coordinates
     if (structure.units.length === 1) {
         return Vec3.create(caPositions[0], caPositions[1], caPositions[2]);
     } else {
-    // if more than one chain => average of coordinates of the first chain
-        const tmpMatrixPos = Vec3.zero();
+    // if more than one chain, return average of the coordinates of the first polymer chain
+        const pos = Vec3.zero();
+        const center = Vec3.zero();
         let atomIndexs;
         if (structure.units[0].props.polymerElements) {
             atomIndexs = structure.units[0].props.polymerElements;
         } else {
             atomIndexs = structure.units[0].elements;
         }
-        const firstChainPositions = [];
-        const readPosition = structure.units[0].conformation.position;
+        const { position } = structure.units[0].conformation;
         for (let i = 0; i < atomIndexs.length; i++) {
-            const coordinates = readPosition(atomIndexs[i], tmpMatrixPos);
-            for (let j = 0; j < coordinates.length; j++) {
-                firstChainPositions.push(coordinates[j]);
-            }
+            position(atomIndexs[i], pos);
+            Vec3.add(center, center, pos);
         }
-        let sumX = 0;
-        let sumY = 0;
-        let sumZ = 0;
-        for (let i = 0; i < firstChainPositions.length; i += 3) {
-            sumX += firstChainPositions[i];
-            sumY += firstChainPositions[i + 1];
-            sumZ += firstChainPositions[i + 2];
-        }
-        const averagePosition = Vec3.zero();
-        averagePosition[0] = sumX / atomIndexs.length;
-        averagePosition[1] = sumY / atomIndexs.length;
-        averagePosition[2] = sumZ / atomIndexs.length;
-        return averagePosition;
+        Vec3.scale(center, center, 1 / atomIndexs.length);
+        return center;
     }
 }

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -71,6 +71,7 @@ export class FocusFirstResidue implements FocusFactoryI {
 }
 
 function getFirstResidueOrAveragePosition(structure: Structure, caPositions: Float32Array): Vec3 {
+    //TODO Is this the best way to test single chain?
     // if only one chain => first residue coordinates
     if (structure.units.length === 1) {
         return Vec3.create(caPositions[0], caPositions[1], caPositions[2]);

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -80,8 +80,9 @@ function getFirstResidueOrAveragePosition(structure: Structure, caPositions: Flo
         const tmpMatrixPos = Vec3.zero();
         const AtomIndexs = structure.units[0].elements;
         const firstChainPositions = [];
+        const readPosition = structure.units[0].conformation.position;
         for (let i = 0; i < AtomIndexs.length; i++) {
-            const coordinates = structure.units[0].conformation.position(AtomIndexs[i], tmpMatrixPos);
+            const coordinates = readPosition(AtomIndexs[i], tmpMatrixPos);
             for (let j = 0; j < coordinates.length; j++) {
                 firstChainPositions.push(coordinates[j]);
             }

--- a/src/focus-camera/focus-first-residue.ts
+++ b/src/focus-camera/focus-first-residue.ts
@@ -78,11 +78,16 @@ function getFirstResidueOrAveragePosition(structure: Structure, caPositions: Flo
     } else {
     // if more than one chain => average of coordinates of the first chain
         const tmpMatrixPos = Vec3.zero();
-        const AtomIndexs = structure.units[0].elements;
+        let atomIndexs;
+        if (structure.units[0].props.polymerElements) {
+            atomIndexs = structure.units[0].props.polymerElements;
+        } else {
+            atomIndexs = structure.units[0].elements;
+        }
         const firstChainPositions = [];
         const readPosition = structure.units[0].conformation.position;
-        for (let i = 0; i < AtomIndexs.length; i++) {
-            const coordinates = readPosition(AtomIndexs[i], tmpMatrixPos);
+        for (let i = 0; i < atomIndexs.length; i++) {
+            const coordinates = readPosition(atomIndexs[i], tmpMatrixPos);
             for (let j = 0; j < coordinates.length; j++) {
                 firstChainPositions.push(coordinates[j]);
             }
@@ -96,9 +101,9 @@ function getFirstResidueOrAveragePosition(structure: Structure, caPositions: Flo
             sumZ += firstChainPositions[i + 2];
         }
         const averagePosition = Vec3.zero();
-        averagePosition[0] = sumX / AtomIndexs.length;
-        averagePosition[1] = sumY / AtomIndexs.length;
-        averagePosition[2] = sumZ / AtomIndexs.length;
+        averagePosition[0] = sumX / atomIndexs.length;
+        averagePosition[1] = sumY / atomIndexs.length;
+        averagePosition[2] = sumZ / atomIndexs.length;
         return averagePosition;
     }
 }

--- a/src/focus-camera/focus-util.ts
+++ b/src/focus-camera/focus-util.ts
@@ -6,19 +6,17 @@
 
 import { Vec3 } from 'molstar/lib/mol-math/linear-algebra';
 
-export function calculateDisplacement(positions: Float32Array, origin: Vec3, normalDir: Vec3) {
-    const toReturn = new Float32Array(positions.length / 3);
+export function calculateDisplacement(position: Vec3, origin: Vec3, normalDir: Vec3) {
     const A = normalDir[0];
     const B = normalDir[1];
     const C = normalDir[2];
     const D = -A * origin[0] - B * origin[1] - C * origin[2];
-    for (let i = 0; i < positions.length; i += 3) {
-        const x = positions[i];
-        const y = positions[i + 1];
-        const z = positions[i + 2];
-        const displacement = (A * x + B * y + C * z + D) / Math.sqrt(A * A + B * B + C * C);
-        toReturn[i / 3] = displacement;
-    }
-    return toReturn;
+
+    const x = position[0];
+    const y = position[1];
+    const z = position[2];
+
+    const displacement = (A * x + B * y + C * z + D) / Math.sqrt(A * A + B * B + C * C);
+    return displacement;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,19 @@ addBasicArgs(modelsParser);
 const allParser = subparsers.add_parser('all', { add_help: true });
 addBasicArgs(allParser);
 
+
+const chainListParser = subparsers.add_parser('chain-list', { add_help: true });
+addBasicArgs(chainListParser);
+chainListParser.add_argument('asmIndex', {
+    action: 'store',
+    help: 'assembly index',
+});
+chainListParser.add_argument('chainList', {
+    action: 'store',
+    nargs: '*',
+    help: 'chain chainName1 [operator1] chain chainName2 [operator2] ...'
+});
+
 const args = parser.parse_args();
 
 if (!fs.existsSync(args.in)) {
@@ -124,6 +137,9 @@ async function main() {
             break;
         case 'models':
             await renderer.renderModels(trajectory, args.out, fileName);
+            break;
+        case 'chain-list':
+            await renderer.renderChainList(args.asmIndex, args.chainList, await Task.resolveInContext(trajectory.representative), args.out, fileName);
             break;
     }
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -439,7 +439,8 @@ export class ImageRenderer {
                 current.push(str);
             }
         }
-        divided.push(current);
+        if (current.length > 0)
+            divided.push(current);
         const pairList = divided.map(arr => arr.join('-'));
         const chainString = pairList.join(' ');
         console.log(`Rendering ${fileName} assembly ${asmId} chainList ${chainString}`);
@@ -459,7 +460,7 @@ export class ImageRenderer {
                 }));
                 chainStructures.push(structureChain);
             } else {
-                console.error('incorrect chainList format');
+                console.error('Incorrect chainList format');
                 process.exit(1);
             }
         }


### PR DESCRIPTION
1. First Chain Based Re-Orientation: If there is more than one chain in the structure, the new version will use the average of position of the first chain coordinates to decide the orientation of the picture based on the rule that the average should be in the first quadrant. 

2. Chain List Rendering: the new features will render chain list in the following format `molrender chain-list /path/to/5cbg.cif /path/to/out/ asmIndex chain chainName1 [operator1] chain chainName2 [operator2] ...`

For example: `molrender chain-list 1a6d.cif outpath 0 chain A ASM_1 chain A ASM_4` will generate:
![1a6d_chain-list-assembly-1-A-ASM_1-A-ASM_4](https://user-images.githubusercontent.com/92659167/207998532-44893e0d-c9a0-4729-9d76-f4c7ce789ecd.png)

`molrender chain-list 1a6d.cif outpath 0 chain A chain B ASM_2`
![1a6d_chain-list-assembly-1-A-B-ASM_2](https://user-images.githubusercontent.com/92659167/207998605-4268c338-6499-4588-bb4c-10332fa78081.png)

`molrender chain-list 1a6d.cif outpath 0 chain B ASM_1 chain B ASM_3 chain A ASM_6 chain A ASM_4 chain A ASM_7`
![1a6d_chain-list-assembly-1-B-ASM_1-B-ASM_3-A-ASM_6-A-ASM_4-A-ASM_7](https://user-images.githubusercontent.com/92659167/207998678-b70db902-cd39-48e7-bf32-d5929d3385bf.png)
